### PR TITLE
Expose environment variables for jjc

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ square brackets are optional.
 |------------|------------------------|----------------------------|------------------|-------------|
 | `action`   | target                 | message                    | n/a              | Send an action message to a user or channel.
 | `me`       | target                 | message                    | n/a              | An alias for `action`.
-| `away`     | away text*             | n/a                        | n/a              | Mark yourself as away. Without parameters it unsets away.
+| `away`     | away text\*            | n/a                        | n/a              | Mark yourself as away. Without parameters it unsets away.
 | `invite`   | nickname               | channel                    | n/a              | Invite a user to a channel.
 | `join`     | channel1[,channel2]... | [password1[,password2]...] | n/a              | Join channels.
 | `kick`     | channel                | nickname                   | [reason]         | Kick a user from a channel.

--- a/jjd.c
+++ b/jjd.c
@@ -191,6 +191,14 @@ main(int argc, char **argv)
 	const char *port   = variable("IRC_PORT",   DEFAULT_PORT);
 	const char *cmd    = variable("IRC_CLIENT", DEFAULT_CMD);
 
+        setenv("IRC_DIR", DEFAULT_DIR, 0);
+        setenv("IRC_HOST", DEFAULT_HOST, 0);
+        setenv("IRC_PORT", DEFAULT_PORT, 0);
+        setenv("IRC_CLIENT", DEFAULT_CMD, 0);
+        setenv("IRC_NICK", getenv("USER"), 0);
+        setenv("IRC_REALNAME", getenv("USER"), 0);
+        setenv("IRC_USER", getenv("USER"), 0);
+
 	prog = argc ? argv[0] : "jjd";
 
 	fifo_fd = fifo_setup(ircdir, host);


### PR DESCRIPTION
From the README it sounds like this is where you were headed already, but this change allows one to start `jjd` without having to set any env vars, just using default values.

I don't know any C so feel free to close or rewrite this entirely. :-)