### PR TITLE
flush the output buffer to force the last line to be printed

### DIFF
--- a/jjp
+++ b/jjp
@@ -91,6 +91,7 @@ BEGIN {
 } {
 	if (NF < 2) {
 		printf "\n%s", $0
+		fflush()
 		next
 	}
 
@@ -120,6 +121,7 @@ BEGIN {
 	# When JJ_SERVERLOG is set, print messages in the default color.
 	if (ENVIRON["JJ_SERVERLOG"] != "") {
 		printf "\n\033[%sm%s\033[0m %s", dcolor, time, msg
+		fflush()
 		next
 	}
 
@@ -127,6 +129,7 @@ BEGIN {
 	if (nick == "-") {
 		printf "\n\033[%sm%s \033[%sm%s\033[0m",
 			dcolor, time, "38;5;8", msg
+		fflush()
 		next
 	}
 
@@ -153,4 +156,5 @@ BEGIN {
 
 	printf "\n\033[%sm%s\033[0m \033[%sm%10s\033[0m: %s",
 		dcolor, time, ncolor, nick, msg
+	fflush()
 } END { print "" }


### PR DESCRIPTION
Some awk implementation keep the last line in the buffer, and do not print it
until a '\n' is printed.  Given that jjp uses printf("\n%s") rather than
printf("%s\n"), the awk implementation that are line-buffered will not print
the last line without that.

Note that POSIX awk(1p) does not have this function, and system("") could
be used as a workaround instead, which would have the side effect to spawn
a shell doing nothing for every line printed.

On the other hand, it is present on gawk, mawk, nawk ("one true awk", which still kick through, last commit two days ago!), and busybox awk.