### PR TITLE
Fix jjd build on illumos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /usr
 INCS = -I. -I/usr/include
-LIBS = -L/usr/lib -lc
+LIBS = -L/usr/lib -lc -lsocket
 
 CC = cc
 CPPFLAGS = -D_POSIX_C_SOURCE=200809L

--- a/jjd.c
+++ b/jjd.c
@@ -28,6 +28,27 @@
 static const char *prog;
 static const int *pipe_fd;
 
+#if defined(__sun) && defined(__SVR4)
+int
+dprintf(int fd, const char *restrict format, ...)
+{
+	// As of January 2022, illumos does not have dprintf
+	// yet (see man printf). Provide a wrapper:
+        va_list ap;
+        FILE *f = fdopen(fd, "w");
+
+        if (!f) {
+                return -1;
+        }
+
+        va_start(ap, format);
+        int result = fprintf(f, format, ap);
+        va_end(ap);
+
+        return result;
+}
+#endif
+
 static void
 die(const char *fmt, ...)
 {


### PR DESCRIPTION
* Adds `-lsocket` so the network-related functions are found.
* Provides `dprintf()` which [isn't there (yet)](https://illumos.org/man/3C/printf).

Seems to fix #10 (at least on my OmniOS system).